### PR TITLE
Api subclassing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,8 @@ History
   https://api.3di.live instead of https://api.3di.live/v3.0). A warning will be emitted if
   a version is included.
 
+- Make V3AlphaApi a subclass of V3BetaApi, and V3BetaApi a superset of V3Api.
+
 
 3.0.29 (2021-06-02)
 -------------------

--- a/threedi_api_client/versions.py
+++ b/threedi_api_client/versions.py
@@ -29,7 +29,7 @@ try:
 
     API_VERSIONS["v3-alpha"] = V3AlphaApi
 except ImportError:
-    pass
+    API_VERSIONS["v3-alpha"] = API_VERSIONS["v3-beta"]
 
 
 VERSION_REGEX = re.compile(r"(.*)\/v[0-9./]+$")

--- a/threedi_api_client/versions.py
+++ b/threedi_api_client/versions.py
@@ -7,18 +7,29 @@ API_VERSIONS = {
 }
 
 try:
-    from .openapi import V3AlphaApi
-    API_VERSIONS["v3-alpha"] = V3AlphaApi
+    from .openapi import V3BetaApi as _V3BetaApi
+
+    # Make any missing method on V3BetaApi dispatch to V3Api, so that
+    # v3-beta is a superset of v3.
+    class V3BetaApi(_V3BetaApi, V3Api):
+        pass
+
+    API_VERSIONS["v3-beta"] = V3BetaApi
 except ImportError:
-    pass
+    API_VERSIONS["v3-beta"] = V3Api
 
 
 try:
-    from .openapi import V3BetaApi
-    API_VERSIONS["v3-beta"] = V3BetaApi
+    from .openapi import V3AlphaApi as _V3AlphaApi
+
+    # Make any missing method on V3AlphaApi dispatch to V3BetaApi, so that
+    # v3-alpha is a superset of v3-beta (which is a superset of v3).
+    class V3AlphaApi(_V3AlphaApi, API_VERSIONS["v3-beta"]):
+        pass
+
+    API_VERSIONS["v3-alpha"] = V3AlphaApi
 except ImportError:
     pass
-
 
 
 VERSION_REGEX = re.compile(r"(.*)\/v[0-9./]+$")


### PR DESCRIPTION
From https://github.com/nens/rfcs-for-lizard/blob/master/0002-api_versioning.md :

> The "alpha" is a superset of "beta" which is a superset of "stable". It is allowed to put redirects alpha -> beta and beta -> stable and as such hide them in the API endpoint listing and in the OpenAPI specification.

This currently is not the case. This PR does some subclassing in version.py to make it so.

```
In [4]: len(dir(ThreediApi(env_file=".env", version="v3-beta")))
Out[4]: 903

In [5]: len(dir(ThreediApi(env_file=".env", version="v3")))
Out[5]: 903

In [6]: len(dir(ThreediApi(env_file=".env", version="v3-alpha")))
Out[6]: 957
```