### PR TITLE
Add CC flow

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,10 @@ History
 - Added OAuth2 token and OAuth2 token refresh capability (for both public
   and private clients).
 
+- Allow usage of the API client without supplying a refresh token.
+
+- Added automatic refresh for OAuth2 tokens obtained through the client credentials grant.
+
 
 4.0.0 (2022-02-11)
 ------------------

--- a/tests/test_threedi_api.py
+++ b/tests/test_threedi_api.py
@@ -110,7 +110,7 @@ def test_init_missing_config(key, config):
 
 
 @pytest.mark.parametrize(
-    "key", ["THREEDI_API_HOST", "THREEDI_API_ACCESS_TOKEN", "THREEDI_API_REFRESH_TOKEN"]
+    "key", ["THREEDI_API_HOST", "THREEDI_API_ACCESS_TOKEN"]
 )
 def test_init_missing_oauth2_config(key, oauth2_config):
     del oauth2_config[key]
@@ -119,7 +119,7 @@ def test_init_missing_oauth2_config(key, oauth2_config):
 
 
 @pytest.mark.parametrize(
-    "key", ["THREEDI_API_HOST", "THREEDI_API_ACCESS_TOKEN", "THREEDI_API_REFRESH_TOKEN"]
+    "key", ["THREEDI_API_HOST", "THREEDI_API_ACCESS_TOKEN"]
 )
 def test_init_missing_token_config(key, token_config):
     del token_config[key]

--- a/threedi_api_client/api.py
+++ b/threedi_api_client/api.py
@@ -24,7 +24,17 @@ class ThreediApi:
     Consult the docstrings of these methods for further information
 
     ThreediApi requires a hostname and user credentials. These can either be stored in
-    a ``.env`` file, supplied via environment variables, or passed as a config dictionairy.
+    a ``.env`` file, supplied via environment variables, or passed as a config dictionary.
+
+    Alternatively, supply an ACCESS_TOKEN. If the ACCESS_TOKEN has expired, there are 3 methods
+    implemented for automatic token renewal:
+
+    - refresh token without client secret: supply a REFRESH_TOKEN
+    - refresh token with client secret: supply a REFRESH_TOKEN and CLIENT_SECRET
+    - client credentials flow: supply a CLIENT_SECRET
+
+    For the client_credentials flow, direct usage of ``threedi_api_client.auth.refresh_oauth2_token``
+    is recommended to fetch the initial access token.
 
     1) A sample ``.env`` file could look like this::
 
@@ -149,7 +159,7 @@ class ThreediApi:
         client_secret = user_config.get("THREEDI_API_CLIENT_SECRET")
 
         basic = all(x for x in (username, password))
-        tokens = all(x for x in (access_token, refresh_token))
+        tokens = bool(access_token)
         if tokens and basic or (not tokens and not basic):
             raise ValueError(
                 "ThreediAPI requires either THREEDI_API_PASSWORD or "


### PR DESCRIPTION
This keeps threedi-api-client in sync with the work I did for the machine-to-machine authentication for the raster service.

Possibly this can be used as well for the worker -> API communication or scheduler -> API communication. That is more secure than sending a root password. But then the ThreediApiClient should become a singleton or else we end up fetching tokens from AWS Cognito all the time.

Example how-to-use script can be found over here: https://github.com/nens/raster-service-api-client#getting-started

