### PR TITLE
[DONE] Disabled auto content_type header in aiohttp

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,8 @@ History
 4.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support S3 (object storage) temp-urls in upload/download functions in aio/files.py by
+  disabling the automatic addition of the 'content-type' header by aiohttp.
 
 
 4.0.1 (2022-06-08)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ requirements = [
 aio_requirements = ["aiohttp>=3.6.3", "aiofiles"]
 
 # Note: mock contains a backport of AsyncMock
-test_requirements = ["pytest", "pytest-asyncio", "mock", 'pyjwt']
+test_requirements = ["pytest", "pytest-asyncio~=0.18", "mock", 'pyjwt']
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ requirements = [
 aio_requirements = ["aiohttp>=3.6.3", "aiofiles"]
 
 # Note: mock contains a backport of AsyncMock
-test_requirements = ["pytest", "pytest-asyncio~=0.18.3", "mock", 'pyjwt']
+test_requirements = ["pytest", "pytest-asyncio<0.19", "mock", 'pyjwt']
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ requirements = [
 aio_requirements = ["aiohttp>=3.6.3", "aiofiles"]
 
 # Note: mock contains a backport of AsyncMock
-test_requirements = ["pytest", "pytest-asyncio~=0.18", "mock", 'pyjwt']
+test_requirements = ["pytest", "pytest-asyncio~=0.18.3", "mock", 'pyjwt']
 
 
 setup(

--- a/tests/test_files_aio.py
+++ b/tests/test_files_aio.py
@@ -299,11 +299,8 @@ async def test_upload_fileobj_with_md5(aio_request, fileobj, upload_response):
     aio_request.return_value = upload_response
     await upload_fileobj("some-url", fileobj, md5=b"abcd")
 
-    # base64.b64encode(b"abcd")).decode()
-    expected_md5 = "YWJjZA=="
-
     args, kwargs = aio_request.call_args
-    assert kwargs["headers"] == {"Content-Length": "39", "Content-MD5": expected_md5}
+    assert kwargs["headers"] == {"Content-Length": "39"}
 
 
 @pytest.mark.asyncio

--- a/threedi_api_client/aio/files.py
+++ b/threedi_api_client/aio/files.py
@@ -220,7 +220,7 @@ async def download_fileobj(
         "retries": retries,
         "backoff_factor": backoff_factor,
     }
-    async with aiohttp.ClientSession(connector=connector) as client:
+    async with aiohttp.ClientSession(connector=connector, skip_auto_headers={'content-type'}) as client:
         # start with a single chunk to learn the total file size
         response, file_size = await _download_request(
             client, 0, chunk_size, **request_kwargs
@@ -467,10 +467,8 @@ async def upload_fileobj(
     headers = {
         "Content-Length": str(file_size),
     }
-    if md5 is not None:
-        headers["Content-MD5"] = base64.b64encode(md5).decode()
 
-    async with aiohttp.ClientSession(connector=connector) as client:
+    async with aiohttp.ClientSession(connector=connector, skip_auto_headers={'content-type'}) as client:
         request = partial(
             _upload_request,
             client,


### PR DESCRIPTION
@caspervdw: Maybe remove all of the md5 stuffs? Signature is going to change -> not backwards compatible. 

Tested sync version -> works.